### PR TITLE
Change in WindowStyle to run the code on a cloud

### DIFF
--- a/PhysIO/code/tapas_physio_get_default_fig_params.m
+++ b/PhysIO/code/tapas_physio_get_default_fig_params.m
@@ -34,8 +34,7 @@ scrsz = get(0,'ScreenSize');
 
 scrsz = min([1 1 1440 900], scrsz);
 fh = figure('Position',[scrsz(1:2) xscale*scrsz(3) yscale*scrsz(4)]);
-set(fh, 'WindowStyle', 'docked');
-%fh = figure('Position',[scrsz(1:2) xscale*scrsz(3) yscale*scrsz(4)], 'Hidden', 'on');
+set(fh, 'WindowStyle', 'modal');
 
 MyColors = [ ...
     1.0000,         0,         0; ...


### PR DESCRIPTION
WindowStyle was changed in tapas_physio_get_default_fig_params.m from 'docked' to 'modal' so the code would run on a cloud server. The docked style generated the error 'Cannot set WindowStyle to 'docked''.