### PR TITLE
noise ROIs : final ROIs review, 3D erosion

### DIFF
--- a/Contributor-License-Agreement.md
+++ b/Contributor-License-Agreement.md
@@ -14,6 +14,7 @@ Name                     | Company/Institution/Address | City      | Country | E
 ------------------------ | --------------------------- | --------- | ------- | ----------------------
 Lars Kasper              | TNU, University of Zurich   | Zurich    | CH      | mrikasper
 Eduardo Aponte           | TNU, University of Zurich   | Zurich    | CH      | tnutapas
+Benoît Béranger          | CENIR, ICM                  | Paris     | FR      | benoitberanger
 **- Add Entry here -**   | **- Add Entry here -**      | **Add**   | **Add** | **Add**                    
 
 (hereinafter referred to as "Contributor")

--- a/PhysIO/code/tapas_physio_cfg_matlabbatch.m
+++ b/PhysIO/code/tapas_physio_cfg_matlabbatch.m
@@ -1470,6 +1470,8 @@ verbose.help   = {
     '                            Fig 5: time course of all sampled RETROICOR'
     '                                   regressors'
     '                            Fig 6: final multiple_regressors matrix'
+    '                            SPM Graphics : noise ROI before VS after'
+    '                                   (reslice) + threshold + erosion'
     ''
     ' 3 = all plots'
     '                            Fig 1: raw phys logfile data'
@@ -1485,6 +1487,8 @@ verbose.help   = {
     '                            Fig 8: time course of all sampled RETROICOR'
     '                                   regressors'
     '                            Fig 9: final multiple_regressors matrix'
+    '                            SPM Graphics : noise ROI before VS after'
+    '                                   (reslice) + threshold + erosion'
     
     };
 verbose.val    = {level fig_output_file use_tabs};

--- a/PhysIO/code/tapas_physio_cfg_matlabbatch.m
+++ b/PhysIO/code/tapas_physio_cfg_matlabbatch.m
@@ -1191,6 +1191,7 @@ noise_rois_yes.val  = {fmri_files, roi_files, roi_thresholds, n_voxel_crop, ...
 noise_rois_yes.help = {
     'Include Noise ROIs model'
     '(Principal components of anatomical regions), similar to aCompCor, Behzadi et al. 2007'
+    'Noise ROIs will be shown in SPM ''Graphics'' window'
     };
 
 

--- a/PhysIO/code/tapas_physio_cfg_matlabbatch.m
+++ b/PhysIO/code/tapas_physio_cfg_matlabbatch.m
@@ -1089,6 +1089,30 @@ hrv.help = {
 %--------------------------------------------------------------------------
 
 %--------------------------------------------------------------------------
+% force_coregister
+%--------------------------------------------------------------------------
+
+force_coregister        = cfg_menu;
+force_coregister.tag    = 'force_coregister';
+force_coregister.name   = 'Force Coregister : Estimate & Reslice of the noise ROIs';
+force_coregister.labels = {'Yes', 'No'};
+force_coregister.values = {'Yes', 'No'};
+force_coregister.val    = {'Yes'}; % default value, discussion in https://github.com/translationalneuromodeling/tapas/pull/34
+force_coregister.help   = {
+    'Noise ROIs volumes must have the same geometry as the functional time series.'
+    'It means same affine transformation(space) and same matrix(voxel size)'
+    ''
+    'Yes - Coregister : Estimate & Reslice will be performed on the noise NOIs,'
+    'so their geometry (space + voxel size) will match the fMRI volume.'
+    ''
+    'No - Geometry will be tested :'
+    '1) If they match, continue'
+    '2) If they don''t match, perform a Coregister : Estimate & Reslice as fallback'
+    ''
+    };
+
+
+%--------------------------------------------------------------------------
 % fmri_files
 %--------------------------------------------------------------------------
 
@@ -1190,8 +1214,8 @@ noise_rois_no.help = {'Noise ROIs not used'};
 noise_rois_yes      = cfg_branch;
 noise_rois_yes.tag  = 'yes';
 noise_rois_yes.name = 'Yes';
-noise_rois_yes.val  = {fmri_files, roi_files, roi_thresholds, n_voxel_crop, ...
-    n_components};
+noise_rois_yes.val  = {fmri_files, roi_files, force_coregister, roi_thresholds,...
+    n_voxel_crop, n_components};
 noise_rois_yes.help = {
     'Include Noise ROIs model'
     '(Principal components of anatomical regions), similar to aCompCor, Behzadi et al. 2007'

--- a/PhysIO/code/tapas_physio_cfg_matlabbatch.m
+++ b/PhysIO/code/tapas_physio_cfg_matlabbatch.m
@@ -1111,7 +1111,11 @@ roi_files         = cfg_files;
 roi_files.tag     = 'roi_files';
 roi_files.name    = 'Noise ROI Image File(s)';
 roi_files.val     = {{''}};
-roi_files.help    = {'Masks/tissue probability maps characterizing where noise resides'};
+roi_files.help    = {
+    'Masks/tissue probability maps characterizing where noise resides'
+    'Theses volumes must be in the same space as the functional volume,'
+    'where the time series will be extracted.'
+    };
 roi_files.filter  = '.*';
 roi_files.ufilter = '.nii$|.img$';
 roi_files.num     = [0 Inf];

--- a/PhysIO/code/tapas_physio_create_noise_rois_regressors.m
+++ b/PhysIO/code/tapas_physio_create_noise_rois_regressors.m
@@ -70,7 +70,9 @@ if numel(n_components) == 1
 end
 
 % Show the noise ROIs before reslice, threshold and erosion
-spm_check_registration( roi_files{:} )
+if verbose.level >= 2
+    spm_check_registration( roi_files{:} )
+end
 
 % TODO: what if different geometry of mask and fmri data?
 %       or several fmri files given?
@@ -122,14 +124,16 @@ for r = 1:nRois
     spm_write_vol(Vroi,roi);
     
     % Overlay the final noise ROI (code from spm_orthviews:add_c_image)
-    spm_orthviews('addcolouredimage',r,Vroi.fname ,[1 0 0])
-    hlabel = sprintf('%s (%s)',Vroi.fname ,'Red');
-    c_handle    = findobj(findobj(st.vols{r}.ax{1}.cm,'label','Overlay'),'Label','Remove coloured blobs');
-    ch_c_handle = get(c_handle,'Children');
-    set(c_handle,'Visible','on');
-    uimenu(ch_c_handle(2),'Label',hlabel,'ForegroundColor',[1 0 0],...
-        'Callback','c = get(gcbo,''UserData'');spm_orthviews(''context_menu'',''remove_c_blobs'',2,c);');
-    spm_orthviews('redraw')
+    if verbose.level >= 2
+        spm_orthviews('addcolouredimage',r,Vroi.fname ,[1 0 0])
+        hlabel = sprintf('%s (%s)',Vroi.fname ,'Red');
+        c_handle    = findobj(findobj(st.vols{r}.ax{1}.cm,'label','Overlay'),'Label','Remove coloured blobs');
+        ch_c_handle = get(c_handle,'Children');
+        set(c_handle,'Visible','on');
+        uimenu(ch_c_handle(2),'Label',hlabel,'ForegroundColor',[1 0 0],...
+            'Callback','c = get(gcbo,''UserData'');spm_orthviews(''context_menu'',''remove_c_blobs'',2,c);');
+        spm_orthviews('redraw')
+    end
     
     Yroi = Yimg(roi(:)==1, :); % Time series of the fMRI volume in the noise ROIs
     

--- a/PhysIO/code/tapas_physio_create_noise_rois_regressors.m
+++ b/PhysIO/code/tapas_physio_create_noise_rois_regressors.m
@@ -36,7 +36,7 @@ function [R_noise_rois, noise_rois, verbose] = tapas_physio_create_noise_rois_re
 %
 % $Id$
 
-% TODO: visualization of Rois, components/mean and spatial loads in ROIs
+% TODO: components/mean and spatial loads in ROIs
 
 global st % to overlay the final ROIs, using spm_orthviews
 
@@ -69,7 +69,7 @@ if numel(n_components) == 1
     n_components = repmat(n_components, 1, nRois);
 end
 
-% Show the noise ROIs before threshold and erosion
+% Show the noise ROIs before reslice, threshold and erosion
 spm_check_registration( roi_files{:} )
 
 % TODO: what if different geometry of mask and fmri data?
@@ -113,18 +113,17 @@ for r = 1:nRois
     for iter = 1 : n_voxel_crop(r)
         roi = spm_erode(roi);                    % using spm_erode, a compiled mex file
         % roi= imerode(roi, strel('sphere', 1)); % using imerode (+ strel) from Image Processing Toolbox
-        % NB : the result exactly the same with spm_erode or imerode
+        % NB : the result is exactly the same with spm_erode or imerode
     end
     
-    % Write in a volume noise ROIs, after threshold and erosiob
+    % Write the final noise ROIs in a volume, after relice, threshold and erosion
     [fpRoi,fnRoi] = fileparts(Vroi.fname);
     Vroi.fname = fullfile(fpRoi, sprintf('noiseROI_%s.nii', fnRoi));
     spm_write_vol(Vroi,roi);
     
-    % Overlay the final noise ROI
+    % Overlay the final noise ROI (code from spm_orthviews:add_c_image)
     spm_orthviews('addcolouredimage',r,Vroi.fname ,[1 0 0])
     hlabel = sprintf('%s (%s)',Vroi.fname ,'Red');
-    
     c_handle    = findobj(findobj(st.vols{r}.ax{1}.cm,'label','Overlay'),'Label','Remove coloured blobs');
     ch_c_handle = get(c_handle,'Children');
     set(c_handle,'Visible','on');


### PR DESCRIPTION
Hello,

Here is PR that includes some features regarding the PhysIO noiseROIs processing.
There are 3 features :
- Write noiseROIs in a volume, after _threshold_ and _erosion_
- Display theses final ROIs using `spm_orthviews` : original ROI + final ROI as overlay
- Erosion is now 3D, using `spm_erode` (mex file, embedded in SPM)

Also, I would like to (re-)enable the possibility to skip the automatic _reslice_ of the raw noiseROI volume.
But I imagine there is a good reason to disable this possibility.

Benoît