### PR TITLE
PHysIO #180 #166: Removing fieldtrip paths instead of spm

### DIFF
--- a/PhysIO/code/readin/tapas_physio_read_physlogfiles.m
+++ b/PhysIO/code/readin/tapas_physio_read_physlogfiles.m
@@ -93,6 +93,9 @@ switch lower(log_files.vendor)
     case 'siemens_hcp'
         [c, r, t, cpulse, acq_codes, verbose] = ...
             tapas_physio_read_physlogfiles_siemens_hcp(log_files, cardiac_modality, verbose);
+    otherwise
+        error('Invalid vendor "%s". See tapas_physio_new for supported vendors',...
+            log_files.vendor);
 end
 
 % Do not prepend for Siemens Tics, since can be as long as a day

--- a/PhysIO/code/tapas_physio_main_create_regressors.m
+++ b/PhysIO/code/tapas_physio_main_create_regressors.m
@@ -53,18 +53,19 @@ function [physio, R, ons_secs] = tapas_physio_main_create_regressors(varargin)
 %% 0. Set Default parameters
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-% Remove SPM subfolders from path to avoid conflicts with Matlab in-built
-% functions used in PhysIO
-doCorrectPath = true;
-tapas_physio_check_spm(doCorrectPath);
-% Silently check proper Batch Editor integration, if SPM exists,
-% but don't complain, if there is no SPM installed
-isVerbose = false;
-tapas_physio_check_spm_batch_editor_integration(isVerbose);
+oldPath = path();
 
-% Include subfolders of code to path as well
 pathThis = fileparts(mfilename('fullpath'));
-addpath(genpath(pathThis)); 
+ft_paths = which('ft_defaults', '-all')
+
+try
+for p = 1:size(ft_paths, 1)
+    to_remove = fileparts(ft_paths{p});
+    warning('off', 'MATLAB:rmpath:DirNotFound')
+    rmpath(genpath(to_remove));
+    warning('on', 'MATLAB:rmpath:DirNotFound')
+end
+ft_paths = which('ft_defaults', '-all')
 
 % These parameters could become toolbox inputs...
 minConstantIntervalAlertSeconds     = 0.2;
@@ -447,6 +448,12 @@ end % onset_slices
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 [physio.verbose] = tapas_physio_print_figs_to_file(physio.verbose);
+
+catch ME
+    path(oldPath);
+    rethrow(ME);
+end
+path(oldPath);
 
 end
 


### PR DESCRIPTION
Hi, 
I was looking into bypassing issues #180 and #166, 
and found that `PhysIO` already tries to remove sub-directories of spm, but, probably due to outdated version it doesn't work on my installation (my FirledTrip don't have `ft_check_path`).

In this pull request, I replace `ft_check_path` by `ft_defaults`, which is setting paths function,which exists since 2010, and 
I remove paths related to all installations of fieldtrip:
```matlab
oldPath = path();

pathThis = fileparts(mfilename('fullpath'));
ft_paths = which('ft_defaults', '-all')

try
for p = 1:size(ft_paths, 1)
    to_remove = fileparts(ft_paths{p});
    warning('off', 'MATLAB:rmpath:DirNotFound')
    rmpath(genpath(to_remove));
    warning('on', 'MATLAB:rmpath:DirNotFound')
end
ft_paths = which('ft_defaults', '-all')
```
After execution, the original paths are restored.

Alternative, is to remove all paths, using `restoredefaultpaths`, to inshure that PhysIO will run only on bare matlab.

I also added an otherwise with error in switch for the list of vendors.