### PR TITLE
[HGF] Add _namep.m for hgf_binary_mab 

### DIFF
--- a/Contributor-License-Agreement.md
+++ b/Contributor-License-Agreement.md
@@ -19,6 +19,7 @@ Benoît Béranger          | CENIR, ICM                         | Paris     | FR
 Stephan Heunis           | Eindhoven University of Technology | Eindhoven | NL      | jsheunis
 Niklas Bürgi             | SNS, University of Zurich          | Zurich    | CH      | nbuergi
 Alexandre Sayal          | CIBIT, University of Coimbra       | Coimbra   | PT      | alexsayal
+Filippo Ferrari          | ANC, University of Edinburgh       | Edinburgh | UK      | filippoferrari
 **- Add Entry here -**   | **- Add Entry here -**             | **Add**   | **Add** | **Add**                    
 
 (hereinafter referred to as "Contributor")

--- a/HGF/tapas_hgf_binary_mab.m
+++ b/HGF/tapas_hgf_binary_mab.m
@@ -67,7 +67,14 @@ th   = exp(p(5*l-1));
 
 % Add dummy "zeroth" trial
 u = [0; r.u(:,1)];
-y = [1; r.y(:,1)];
+try % For estimation
+    y = [1; r.y(:,1)];
+    r.irr = r.irr;
+catch % For simulation
+    y = [1; r.u(:,2)];
+    r.irr = find(isnan(r.u(:,2)));
+end
+
 
 % Number of trials (including prior)
 n = size(u,1);

--- a/HGF/tapas_hgf_binary_mab_namep.m
+++ b/HGF/tapas_hgf_binary_mab_namep.m
@@ -1,0 +1,25 @@
+function pstruct = tapas_hgf_binary_mab_namep(pvec)
+% --------------------------------------------------------------------------------------------------
+% Copyright (C) 2012-2013 Christoph Mathys, TNU, UZH & ETHZ
+%
+% This file is part of the HGF toolbox, which is released under the terms of the GNU General Public
+% Licence (GPL), version 3. You can redistribute it and/or modify it under the terms of the GPL
+% (either version 3 or, at your option, any later version). For further details, see the file
+% COPYING or <http://www.gnu.org/licenses/>.
+
+
+pstruct = struct;
+
+l = (length(pvec)+1)/5;
+    
+if l ~= floor(l)
+    error('tapas:hgf:UndetNumLevels', 'Cannot determine number of levels');
+end
+
+pstruct.mu_0      = pvec(1:l);
+pstruct.sa_0      = pvec(l+1:2*l);
+pstruct.rho       = pvec(2*l+1:3*l);
+pstruct.ka        = pvec(3*l+1:4*l-1);
+pstruct.om        = pvec(4*l:5*l-1);
+
+return;


### PR DESCRIPTION
The _namep file is missing for the `hgf_binary_mab` model and, because of this, `tapas_simModel.m` fails when run at line 149. 
`tapas_hgf_binary_mab_namep.m` is a copy of `tapas_hgf_binary_namep.m`. 

EDIT 05/10/23
Also fix inputs handling to be consistent with the AR1 model. Inputs to tapas_simModel are now 
`tapas_simModel([inputs responses], 'tapas_hgf_binary_mab', ....etc)`

Filippo